### PR TITLE
Add validation for missing EXTRACT1D extension

### DIFF
--- a/chromatic/rainbows/readers/atoca.py
+++ b/chromatic/rainbows/readers/atoca.py
@@ -83,6 +83,22 @@ def from_atoca(rainbow, filepath, order=1):
     for i_file, f in enumerate(tqdm(filenames, leave=False)):
         hdu_list = fits.open(f)
 
+        has_extract1d = False
+        for i in range(1, len(hdu_list)):
+            if hdu_list[i].header.get("EXTNAME") == "EXTRACT1D" and hdu_list[i].header.get("SPORDER") == order:
+                has_extract1d = True
+                break
+                
+        if not has_extract1d:
+            raise ValueError(
+                f"""
+                No 'EXTRACT1D' extension with order {order} found in the file:
+                {f}
+                
+                Make sure the file contains extractable spectra with the requested order.
+                """
+            )
+            
         # Useful initializations for later.
         quantities = {}
         first_time = True


### PR DESCRIPTION
# Add validation for missing EXTRACT1D extension

This PR implements early validation in the `from_atoca` function to check if the required 'EXTRACT1D' extension exists in the FITS file. If the 'EXTRACT1D' extension is missing, a ValueError with an appropriate message is raised.

The validation occurs early in the function, right after opening the file, to prevent further processing of files without extractable spectra.

## Changes
- Add validation to check if at least one EXTRACT1D extension with the requested order exists in each FITS file
- Raise ValueError with a descriptive message when the extension is missing